### PR TITLE
Update sample-bigtreetech-ebb-canbus-v1.2.cfg

### DIFF
--- a/config/sample-bigtreetech-ebb-canbus-v1.2.cfg
+++ b/config/sample-bigtreetech-ebb-canbus-v1.2.cfg
@@ -9,6 +9,15 @@
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
 #canbus_uuid: 0e0d81e4210c
 
+[temperature_sensor EBBCan_mcu_temp]
+sensor_type: temperature_mcu
+sensor_mcu: EBBCan
+min_temp: 0
+max_temp: 80
+
+[duplicate_pin_override]
+pins: ADC_TEMPERATURE 
+
 [adxl345]
 cs_pin: EBBCan:PB12
 spi_software_sclk_pin: EBBCan:PB10


### PR DESCRIPTION
allow mcu temperature reading, and duplicate_pin_override