### PR TITLE
stm32: Fix setting USB clock with USB to CANbus mode on stm32g4/stm32l4

### DIFF
--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -104,7 +104,7 @@ enable_clock_stm32g4(void)
     RCC->CR |= RCC_CR_PLLON;
 
     // Enable 48Mhz USB clock using clock recovery
-    if (CONFIG_USBSERIAL) {
+    if (CONFIG_USB) {
         RCC->CRRCR |= RCC_CRRCR_HSI48ON;
         while (!(RCC->CRRCR & RCC_CRRCR_HSI48RDY))
             ;

--- a/src/stm32/stm32l4.c
+++ b/src/stm32/stm32l4.c
@@ -96,7 +96,7 @@ enable_clock_stm32l4(void)
     RCC->CR |= RCC_CR_PLLON;
 
     // Enable 48Mhz USB clock using clock recovery
-    if (CONFIG_USBSERIAL) {
+    if (CONFIG_USB) {
         RCC->CRRCR |= RCC_CRRCR_HSI48ON;
         while (!(RCC->CRRCR & RCC_CRRCR_HSI48RDY))
             ;


### PR DESCRIPTION
update usb->canbus kevin tanks.