### PR TITLE
flashsd: Add support for chitu-v6 (#6671)

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -46,6 +46,7 @@ BOARD_DEFS = {
         'mcu': "stm32f103xe",
         'spi_bus': "spi2",
         "cs_pin": "PA15",
+        "conversion_script": "scripts/update_mks_robin.py",
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
@@ -133,6 +134,16 @@ BOARD_DEFS = {
         'mcu': "stm32g0b1xx",
         'spi_bus': "spi1",
         "cs_pin": "PB8"
+    },
+    'chitu-v6': {
+        'mcu': "stm32f103xe",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        "cs_pin": "PC11",
+        #'sdio_bus': 'sdio',
+        "conversion_script": "scripts/update_chitu.py",
+        "firmware_path": "update.cbd",
+        'skip_verify': True
     }
 }
 
@@ -182,7 +193,8 @@ BOARD_ALIASES = {
     'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v2': BOARD_DEFS['fysetc-spider'],
     'robin_v3': BOARD_DEFS['monster8'],
-    'btt-skrat-v1.0': BOARD_DEFS['btt-skrat']
+    'btt-skrat-v1.0': BOARD_DEFS['btt-skrat'],
+    'chitu-v6': BOARD_DEFS['chitu-v6']
 }
 
 def list_boards():

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -74,20 +74,19 @@ def translate_serial_to_tty(device):
     return ttyname, ttyname
 
 def check_need_convert(board_name, config):
-    if board_name.lower().startswith('mks-robin-e3'):
-        # we need to convert this file
-        robin_util = os.path.join(
-            fatfs_lib.KLIPPER_DIR, "scripts/update_mks_robin.py")
-        klipper_bin = config['klipper_bin_path']
-        robin_bin = os.path.join(
+    conv_script = config.get("conversion_script")
+    if conv_script is None:
+        return
+    conv_util = os.path.join(fatfs_lib.KLIPPER_DIR, conv_script)
+    klipper_bin = config['klipper_bin_path']
+    dest_bin = os.path.join(
             os.path.dirname(klipper_bin),
             os.path.basename(config['firmware_path']))
-        cmd = "%s %s %s %s" % (sys.executable, robin_util, klipper_bin,
-                               robin_bin)
-        output("Converting Klipper binary to MKS Robin format...")
-        os.system(cmd)
-        output_line("Done")
-        config['klipper_bin_path'] = robin_bin
+    cmd = "%s %s %s %s" % (sys.executable, conv_util, klipper_bin, dest_bin)
+    output("Converting Klipper binary to custom format...")
+    os.system(cmd)
+    output_line("Done")
+    config['klipper_bin_path'] = dest_bin
 
 
 ###########################################################


### PR DESCRIPTION
Add flashsd configuration for Tronxy x5sa and other printers based on Chitu v6 board.

These boards should support sdio (this is what the schematic details), however I couldn't get this working from a quick try.